### PR TITLE
把套件專案改成netStandard

### DIFF
--- a/ECPay.SDK.Einvoice/ECPay.SDK.Einvoice.csproj
+++ b/ECPay.SDK.Einvoice/ECPay.SDK.Einvoice.csproj
@@ -1,11 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+  <PropertyGroup Label="Project">
+    <OutputType>Library</OutputType>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Nuget">
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Version>0.0.1-preview</Version>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ECPay.SDK.Logistics/ECPay.SDK.Logistics.csproj
+++ b/ECPay.SDK.Logistics/ECPay.SDK.Logistics.csproj
@@ -1,7 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+  <PropertyGroup Label="Project">
+    <OutputType>Library</OutputType>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Nuget">
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Version>0.0.1-preview</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ECPay.SDK.Logistics/ECPayLogisticsClient.cs
+++ b/ECPay.SDK.Logistics/ECPayLogisticsClient.cs
@@ -4,7 +4,7 @@ using ECPay.SDK.Logistics.Validator;
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Net;
+using System.Linq;
 using System.Net.Http;
 using System.Web;
 

--- a/ECPay.SDK/ECPay.SDK.csproj
+++ b/ECPay.SDK/ECPay.SDK.csproj
@@ -1,7 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+  <PropertyGroup Label="Project">
+    <OutputType>Library</OutputType>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  
+  <PropertyGroup Label="Nuget">
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Version>0.0.1-preview</Version>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
1. 把所有預設netCore專案換回netStandard，以獲得更大相容性
2. 修正產生的編譯錯誤